### PR TITLE
Changes to database schema for security

### DIFF
--- a/docs/DatabaseSchema.md
+++ b/docs/DatabaseSchema.md
@@ -5,16 +5,17 @@ Rules:
 
 
 ## users
-- name : string
-- surname : string
-- birth_date : timestamp
-- sex : number (male = 0, female = 1, unspecified = 2)
-- username : string
-- phone_number : string
-- email: string
-- password : string
+- name: string
+- full_name: string
 - status : number
 - profile_image : string (idReference to file in Storage)
+- id_association: string
+- isAdmin: bool
+- private
+  - birth_date : timestamp
+  - sex : number (male = 0, female = 1, unspecified = 2)
+  - phone_number : string
+  - email: string
 - snaps
   - id_location_area : string
   - id_snap : string (idSnapReference to snaps under locationAreas)
@@ -30,13 +31,16 @@ Rules:
   - id_badge : string (idBadge reference to badges)
   - date : timestamp
 - friends
-  id_user : string (idUser references to users)
-  date : timestamp
+  - status: number
+  - id_user : string (idUser references to users)
+  - date : timestamp
 - status : number (status of the profile, ex. 1 = active, 0 = deactive)
 - reports
   - date : timestamp
   - id_association : string
   - association_id_user : string (login)
+  - message: string
+  - status: number
   - reason : string
 
 ## gifts
@@ -63,9 +67,9 @@ Rules:
   - id_snap_image : string (idReference in snapImages in Storage)
   - description : string
   - urgency : number (1= low urgency , 3 = high urgency)
-  - confirmed_urgency : number
-  - confirmed_presence : number (1 = present, 0 = not present)
-  - status : number (ex. 0 = not cleaned , 1 = cleaned)
+  - associationWritable
+    - confirmed_urgency : number
+    - status : number (0 = not cleaned , 1 = cleaned, 2 = not present)
 - authorizedAssociations
   - id_association : string (idAssociation references to associations)
  
@@ -80,25 +84,13 @@ Rules:
 - street_number : string (can have letter ex 10b)
 - locationAreasWorking
   - id_location_areas : string (idReference in locationAreas)
-- LoginUsers
-  - user_name : string
-  - password : string
-  - email : string
-  - type : number 
-  - phone_number : string
+- members
+  -  user: reference
 - payments
   - date : timestamp
   - amount : number
   - purpose : string
   - invoice : string (idReference in parcels in Storage)
-
-
-## admins
-- name : string
-- surnaname : string
-- email: string
-- password : string
-- phone_number : string
 
  ## wasteDisposalCenters (optional)
 - name : string
@@ -120,5 +112,4 @@ Rules:
 ## snapImages
 ## userProfileImages
 ## giftImages
-## badgeImages
-## invoices
+## badguser: references


### PR DESCRIPTION
Due to the limitations of Firestore security rules, I had to rearrange some things in the database schema.
See SnapTrash-cloud repo pull request 4.